### PR TITLE
rpi2: add missing --recursive argument for git clone

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -185,7 +185,7 @@ Then inside the Pi:
 ....
 sudo apt-get update
 sudo apt-get install git make gcc gdb
-git clone https://github.com/cirosantilli/arm-assembly-cheat
+git clone --recursive https://github.com/cirosantilli/arm-assembly-cheat
 cd arm-assembly-cheat
 cd v7
 make NATIVE=y test


### PR DESCRIPTION
Since this repo contains git submodule, add missing --recursive
argment for rpi2's tutorial.

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>